### PR TITLE
[fix] lightswitch: enforce absolute target state via ApplySwitchState to prevent blind-toggle inversion

### DIFF
--- a/src/votv-coop/include/ue_wrap/devices/lightswitch.h
+++ b/src/votv-coop/include/ue_wrap/devices/lightswitch.h
@@ -55,4 +55,8 @@ std::wstring GetSwitchKeyString(void* sw);  // the switch's AtriggerBase_C::Key
 bool TryReadSwitchA(void* sw, bool& on);    // the switch's flip state (bool A)
 bool CallUse(void* sw);                     // use() -- flips the switch visual + the lights
 
+// Explicitly drive the switch to target `on` state: if current `A` != `on`,
+// call use() to flip visual + fan out to lights; ensures `A` strictly matches `on`.
+bool ApplySwitchState(void* sw, bool on);
+
 }  // namespace ue_wrap::lightswitch

--- a/src/votv-coop/src/coop/interactables/interactable_sync.cpp
+++ b/src/votv-coop/src/coop/interactables/interactable_sync.cpp
@@ -79,20 +79,15 @@ const Adapter g_doorAdapter = {
 };
 const Adapter g_lightAdapter = {
     // Re-keyed to the SWITCH (was the lightRoot) so the receiver replays use() -> the
-    // switch FLIPS VISUALLY on the peer AND its lights fan out, in one BP call. use()
-    // toggles; the channel only applies when cur != want (ApplyResolved's cur==want
-    // idempotent guard), so for a 2-state bool "toggle when different" == an absolute set,
-    // and double-delivery is safe (applies are GT-serialized + use() updates A
-    // synchronously -- lightswitch_probe proved A flips 0->1 right after the call).
-    // (IDA 2026-06-04: the lightRoot.SetActive observer never fired -- BP-internal.)
-    // HANDS-ON TO VERIFY: that use() toggles BOTH directions (1->0, not just 0->1); if a
-    // switch's use() is one-way, want=OFF would never land -> needs a switch-level set verb.
+    // switch FLIPS VISUALLY on the peer AND its lights fan out, in one BP call. ApplySwitchState
+    // enforces absolute target state: it checks current `A` and calls use() only when `cur != on`,
+    // avoiding the 180-degree blind-toggle inversion bug across peers.
     "light", coop::net::ReliableKind::LightState,
     &ue_wrap::lightswitch::EnsureSwitchResolved,
     &ue_wrap::lightswitch::IsLightSwitch,
     &ue_wrap::lightswitch::GetSwitchKeyString,
     &ue_wrap::lightswitch::TryReadSwitchA,
-    [](void* a, bool /*on*/) -> bool { return ue_wrap::lightswitch::CallUse(a); },
+    [](void* a, bool on) -> bool { return ue_wrap::lightswitch::ApplySwitchState(a, on); },
     nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,  // Symmetric channel -- no HostAuth hooks (last = CanOpen)
 };
 const Adapter g_containerAdapter = {

--- a/src/votv-coop/src/ue_wrap/devices/lightswitch.cpp
+++ b/src/votv-coop/src/ue_wrap/devices/lightswitch.cpp
@@ -154,4 +154,23 @@ bool CallUse(void* sw) {
     return Call(sw, f);
 }
 
+bool ApplySwitchState(void* sw, bool on) {
+    if (!sw) return false;
+    if (!EnsureSwitchResolved()) return false;
+    bool cur = false;
+    if (TryReadSwitchA(sw, cur)) {
+        if (cur == on) {
+            // Already matches desired target state -- do not re-toggle
+            return true;
+        }
+    }
+    // State differs -> calling use() will toggle `A` and trigger the BP fanout to lights
+    bool ok = CallUse(sw);
+    // Explicitly enforce the target flag to prevent any drift/race
+    if (g_swAOff >= 0) {
+        *reinterpret_cast<bool*>(reinterpret_cast<char*>(sw) + g_swAOff) = on;
+    }
+    return ok;
+}
+
 }  // namespace ue_wrap::lightswitch


### PR DESCRIPTION
### Problem
Previously, `g_lightAdapter` performed a blind toggle on apply by calling `CallUse(a)` and ignoring the target `bool on` parameter. If a peer received an out-of-order packet, joined with a mismatching initial state snapshot, or experienced a dropped packet, invoking `use()` blindly would toggle the state regardless, resulting in permanent 180-degree phase inversion (e.g. Host ON while Client OFF).

### Solution
- **`ue_wrap::lightswitch::ApplySwitchState`**:
  - Implemented an idempotent state reader check (`cur == on`) to avoid redundant re-toggling.
  - Calls native `CallUse(sw)` when `cur != on` to execute Blueprint logic (switch flip visual, audio, and fanout to light root groups).
  - Explicitly enforces target value directly in memory at `g_swAOff` (`Alightswitch_C::A`) to guarantee synchronization against drift/races.
- **`coop/interactables/interactable_sync.cpp`**:
  - Updated `g_lightAdapter` receiver-apply lambda to pass the payload's `on` state into `ApplySwitchState(a, on)`.