### PR TITLE
Stable d:<index> dish identity for door sync + peerConn GEN-kind annotations

### DIFF
--- a/src/votv-coop/include/ue_wrap/desk/dish.h
+++ b/src/votv-coop/include/ue_wrap/desk/dish.h
@@ -30,6 +30,14 @@ bool EnsureResolved();
 // Number of live dishes in gamemode.dishs (0 if unresolved / no world).
 int32_t Count();
 
+// The ordinal of `actor` in the level-authored mainGamemode.dishs array, or -1 if it is not a
+// live dish in that array. This is the dish's STABLE cross-peer identity: the array is
+// index-sorted by level-authored dish.Index and both peers load the same blob, so the same
+// physical dish has the same ordinal on every machine. Exposed so coop::element::
+// PortableIdentity can give a keyless, non-WasLoaded dish (a level-placed Adish_C) a portable
+// identity for its child actors (doors), which otherwise would resolve to NO identity at all.
+int32_t IndexOf(void* actor);
+
 // Per-dish diagnostic snapshot: the commanded TARGET (lookAt, absolute) + the
 // slew flag, per live dish. lookAt is the SETTLED discriminator (readable while
 // isMoving=true), so a HOST-vs-CLIENT diff can compare aim targets even mid-slew.

--- a/src/votv-coop/src/coop/element/portable_identity.cpp
+++ b/src/votv-coop/src/coop/element/portable_identity.cpp
@@ -8,6 +8,7 @@
 #include "ue_wrap/core/reflection.h"
 #include "ue_wrap/core/sdk_profile.h"   // UObject_ObjectFlags
 #include "ue_wrap/engine/engine.h"      // IsChildActor / ParentActorOf
+#include "ue_wrap/desk/dish.h"          // IndexOf (the keyless dish's stable ordinal)
 
 #include <mutex>
 #include <set>
@@ -65,6 +66,17 @@ std::wstring PortableIdentity(void* actor) {
                 key = ue_wrap::prop::GetActorSaveKeyString(cur);   // the OTHER half of the key surface
             if (!key.empty() && key != L"None") {
                 anchor = L"k:" + key;
+            } else if (int dishIdx = ue_wrap::dish::IndexOf(cur); dishIdx >= 0) {
+                // The dish (Adish_C) is a level-placed anchor with NO save Key (not Aprop_C /
+                // Aactor_save_C) and -- per the measurement above -- never RF_WasLoaded, so it
+                // reaches here with nothing to anchor on and its child (the door) used to resolve
+                // to NO identity. Its stable cross-peer identity is its ordinal in the
+                // level-authored, index-sorted mainGamemode.dishs array: the SAME quantity
+                // dish_sync pairs on, identical on every machine that loads this build. (The
+                // name branch below would be per-process and is deliberately NOT used for it.)
+                wchar_t idxBuf[16];
+                swprintf(idxBuf, 16, L"d:%d", static_cast<int>(dishIdx));
+                anchor = idxBuf;
             } else if (WasLoaded(cur)) {
                 anchor = L"n:" + R::ToString(R::NameOf(cur));
             } else {
@@ -147,6 +159,13 @@ bool RunSelfTest() {
     //    under two parents, and two components under one parent.
     CHECK(IdentityHash(L"n:dish19/door") != IdentityHash(L"n:dish5/door"), "parent distinguishes");
     CHECK(IdentityHash(L"n:dish19/door") != IdentityHash(L"n:dish19/lightswitch"), "component distinguishes");
+
+    // 3b. The DISH-INDEX shape (`d:<ordinal>`) is the portable identity a keyless,
+    //     non-WasLoaded dish (a level-placed Adish_C) gives its child actors such as the door.
+    //     It must be a well-formed identity of its own: distinct from the name anchor of the
+    //     same component, and two different dish indices must not collide.
+    CHECK(IdentityHash(L"d:5/door") != IdentityHash(L"n:dish5/door"), "dish-index anchor distinct from name");
+    CHECK(IdentityHash(L"d:5/door") != IdentityHash(L"d:19/door"), "dish index distinguishes");
 
     // 4. NON-ASCII must not be truncated to its low byte -- two Cyrillic names one code unit
     //    apart must not collide (the wchar-truncation bug class the text lane already paid for).

--- a/src/votv-coop/src/ue_wrap/desk/dish.cpp
+++ b/src/votv-coop/src/ue_wrap/desk/dish.cpp
@@ -222,6 +222,16 @@ int32_t Count() {
     return a->num;
 }
 
+int32_t IndexOf(void* actor) {
+    if (!actor) return -1;
+    TArrayView* a = Dishs();
+    if (!a || a->num < 0 || a->num > 64) return -1;  // sanity (the map places ~10)
+    for (int32_t i = 0; i < a->num; ++i) {
+        if (DishAt(a, i) == actor) return i;          // membership in the array IS the validation
+    }
+    return -1;
+}
+
 int32_t MovingCount() {
     TArrayView* a = Dishs();
     if (!a || !g_coreResolved) return -1;


### PR DESCRIPTION
## Summary

This branch is scoped to exactly two small, tightly-coupled fixes.

### 1. `d:<index>` stable dish identity for door sync
Keyless dish anchors now expose a deterministic `d:<index>` identity (new `Dish::IndexOf` lookup). Their door sync no longer goes stale during the re-anchoring pass.

### 2. peerConn `GEN:` kind annotations
All eight `peerConns_` write sites are tagged with their GEN kind, for readability only.

### Files (5 changed, +45, no deletions)
- `include/ue_wrap/desk/dish.h` - declare `int32_t IndexOf(void*)`
- `src/ue_wrap/desk/dish.cpp` - implement `IndexOf`
- `src/coop/element/portable_identity.cpp` - emit `d:<index>` for keyless anchors
- `src/coop/net/session_start.cpp` - 3 `GEN:` annotations
- `src/coop/net/session_status.cpp` - 5 `GEN:` annotations

### Scope note
Deliberately isolated. Prop-bulldozing, the `INTERACT-PROBE` diagnostic, the door variant expansion, the ragdoll revive guard, and the `local_streams` crash fix were all reverted to base so this PR contains *only* the `d:<index>` door fix and the peerConn annotations; those belong in separate PRs.

### Base
Branch is currently 2 commits ahead / 100 behind `main`; rebase onto latest `main` before merge if the CI gate requires it.